### PR TITLE
use the mdbook action in the workflow

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -7,7 +7,8 @@ name: Deploy mdBook site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: 
+     - $default-branch
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -28,20 +29,18 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    env:
-      MDBOOK_VERSION: 0.4.44
     steps:
       - uses: actions/checkout@v4
-      - name: Install mdBook
-        run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
-          rustup update
-          cargo install --version ${MDBOOK_VERSION} mdbook
-      - name: Install mdbook extensions
-        run: |
-          cargo install mdbook-image-size
-          cargo install mdbook-mermaid
-          cargo install mdbook-toc
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: 0.4.44
+      - run: |
+          # Add mdbook-toc, mdbook-mermaid, and mdbook-image-size preprocessors.
+          wget -qO- https://github.com/badboy/mdbook-toc/releases/download/0.14.2/mdbook-toc-0.14.2-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin
+          wget -qO- https://github.com/badboy/mdbook-mermaid/releases/download/v0.14.1/mdbook-mermaid-v0.14.1-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin
+          wget -qO- https://github.com/nicholasphair/mdbook-image-size/releases/download/v.0.2.1/mdbook-image-size-v.0.2.1-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin
+          mdbook build
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Use the github action, `mdbook-action`,  rather than installing everything from scratch.

Takes ~35 seconds to deploy.

